### PR TITLE
New QueueLock plugin to only allow one job queued

### DIFF
--- a/lib/resque/plugins/queue_lock.rb
+++ b/lib/resque/plugins/queue_lock.rb
@@ -1,0 +1,67 @@
+module Resque
+  module Plugins
+    # If you want only one instance of your job queued at a time,
+    # extend it with this module.
+    #
+    # For example:
+    #
+    # require 'resque/plugins/queue_lock'
+    #
+    # class UpdateNetworkGraph
+    #   extend Resque::Plugins::Lock
+    #
+    #   def self.perform(repo_id)
+    #     heavy_lifting
+    #   end
+    # end
+    #
+    # No other UpdateNetworkGraph jobs will be placed on the queue,
+    # the QueueLock class will check Redis to see if any others are
+    # queued with the same arguments before queueing. If another
+    # is queued the enqueue will be aborted.
+    #
+    # If you want to define the key yourself you can override the
+    # `lock` class method in your subclass, e.g.
+    #
+    # class UpdateNetworkGraph
+    #   extend Resque::Plugins::Lock
+    #
+    #   # Run only one at a time, regardless of repo_id.
+    #   def self.lock(repo_id)
+    #     "network-graph"
+    #   end
+    #
+    #   def self.perform(repo_id)
+    #     heavy_lifting
+    #   end
+    # end
+    #
+    # The above modification will ensure only one job of class
+    # UpdateNetworkGraph is running at a time, regardless of the
+    # repo_id. Normally a job is locked using a combination of its
+    # class name and arguments.
+    module QueueLock
+      # Override in your job to control the lock key. It is
+      # passed the same arguments as `perform`, that is, your job's
+      # payload.
+      def lock(*args)
+        "queue_lock:#{name}-#{args.to_s}"
+      end
+
+      def before_enqueue_qlock(*args)
+        Resque.redis.setnx(lock(*args), true)
+      end
+
+      def around_perform_qlock(*args)
+        begin
+          yield
+        ensure
+          # Always clear the lock when we're done, even if there is an
+          # error.
+          Resque.redis.del(lock(*args))
+        end
+      end
+    end
+  end
+end
+

--- a/test/queue_lock_test.rb
+++ b/test/queue_lock_test.rb
@@ -1,0 +1,43 @@
+require 'test/unit'
+require 'resque'
+require 'resque/plugins/queue_lock'
+
+$counter = 0
+
+
+class QueueLockTest < Test::Unit::TestCase
+
+  class Job
+    extend Resque::Plugins::QueueLock
+    @queue = :queue_lock_test
+
+    def self.perform
+      raise "Woah woah woah, that wasn't supposed to happen"
+    end
+  end
+
+  def setup
+    Resque.redis.del('queue:queue_lock_test')
+    Resque.redis.del(Job.lock)
+  end
+
+  def test_lint
+    assert_nothing_raised do
+      Resque::Plugin.lint(Resque::Plugins::QueueLock)
+    end
+  end
+
+  def test_version
+    major, minor, patch = Resque::Version.split('.')
+    assert_equal 1, major.to_i
+    assert minor.to_i >= 17
+    assert Resque::Plugin.respond_to?(:before_enqueue_hooks)
+  end
+
+  def test_lock
+    3.times { Resque.enqueue(Job) }
+
+    assert_equal 1, Resque.redis.llen('queue:queue_lock_test')
+
+  end
+end


### PR DESCRIPTION
This relies on the recently committed "before_enqueue" feature. I've created an alternate lock plugin called QueueLock, that only allows one job to be in the queue at a time.

This fixes a use case for us where even if we only allow one instance of the job (with the same args) to run at a time, we don't want them to run in rapid fire succession if the workers got busy with something else.

I built this by essentially duplicating the Lock plugin and modifying it's behavior. I'm submitting it as an addition to the Lock plugin since it seems to be the right namespace rather than trying  to create an all new plugin.

I was also wondering if perhaps the Lock plugin should really just be modified to work this way instead?

Thanks,
-Ray
