### PR TITLE
New Locksmith failure backend to clean up locks

### DIFF
--- a/lib/resque/failure/locksmith.rb
+++ b/lib/resque/failure/locksmith.rb
@@ -1,0 +1,27 @@
+module Resque
+  module Failure
+
+    # If you use the Resque::Plugins::Lock plugin you're going to want to add
+    # Locksmith to your failure backend chain. The reason for this is that if
+    # your job blows up or dies do to a dirty exit; the lock will not be removed.
+    #
+    # What this results in is a job that silently stops running and leads to
+    # a fit of troubleshooting and anger.
+    #
+    # You'll likely want to use the Multiple failure backends wrapper:
+    # Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Locksmith]
+    # Resque::Failure.backend = Resque::Failure::Multiple
+    class Locksmith < Base
+
+      def save
+        work = payload['class']
+        if work.respond_to?(:lock)
+          lock = work.lock(*payload['args'])
+          Resque.redis.del(lock)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -61,6 +61,11 @@ module Resque
           Resque.redis.del(lock(*args))
         end
       end
+
+      def on_failure_lock(error, *args)
+        Resque.redis.del(lock(*args))
+      end
+
     end
   end
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -37,4 +37,11 @@ class LockTest < Test::Unit::TestCase
 
     assert_equal 1, Resque.redis.llen('queue:lock_test')
   end
+
+  def test_failure_hook_removes_lock
+    Job.before_enqueue_lock
+    assert Resque.redis.exists(Job.lock)
+    Job.on_failure_lock(RuntimeError.new)
+    assert !Resque.redis.exists(Job.lock)
+  end
 end

--- a/test/locksmith_test.rb
+++ b/test/locksmith_test.rb
@@ -1,0 +1,24 @@
+require 'test/unit'
+require 'resque'
+require 'resque/plugins/lock'
+require 'resque/failure/locksmith'
+
+
+class LocksmithTest < Test::Unit::TestCase
+
+  class Job
+    extend Resque::Plugins::Lock
+  end
+
+  def test_should_delete_lock
+    lock = Job.lock('whatever')
+    Job.before_enqueue_lock('whatever')
+
+    payload = {'class' => Job, 'args' => 'whatever'}
+    smith = Resque::Failure::Locksmith.new(nil, nil, nil, payload)
+    smith.save
+
+    assert_nil Resque.redis.get(lock)
+  end
+
+end


### PR DESCRIPTION
When using the Lock plugin locks will be left behind when a job fails due to a
DirtyExit. We've been manually deleting them if we see a DirtyExit error, but
this is unreliable. This is simply a failure backend to handle that case.

I built this out using a Failure backend because there didn't seem to be another way. I'm thinking of adding a failure callback for plugins to resque in the future, whatcha think?
