### PR TITLE
Unlock queue on dequeue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem "resque"
+gem "resque", :git => 'git://github.com/humancopy/resque.git'
 
 group :development do
   gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source :rubygems
 gem "resque"
 
 group :development do
-  gem "turn"
   gem "rake"
 end

--- a/README.md
+++ b/README.md
@@ -43,4 +43,20 @@ UpdateNetworkGraph is queued at a time, regardless of the
 repo_id. Normally a job is locked using a combination of its
 class name and arguments.
 
+It is also possible to define locks which will get released
+BEFORE performing a job by overriding the lock_running? class
+method in your subclass. This is useful in cases where you need
+to get a job queued even if another job on same queue is already
+running, e.g.
+
+    class UpdateNetworkGraph
+      extend Resque::Plugins::Lock
+
+      # Do not lock a running job
+      def self.lock_running?
+        false
+      end
+    end
+
+
 [rq]: http://github.com/defunkt/resque

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -64,11 +64,11 @@ module Resque
       end
 
       def before_enqueue_lock(*args)
-        Resque.redis.setnx(lock(*args), true)
+        Resque.redis.setnx("lock:#{lock(*args)}", true)
       end
 
       def before_dequeue_lock(*args)
-        Resque.redis.del(lock(*args))
+        Resque.redis.del("lock:#{lock(*args)}")
       end
 
       def lock_running?

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -56,13 +56,18 @@ module Resque
         Resque.redis.del(lock(*args))
       end
 
+      def lock_running?
+        true
+      end
+
       def around_perform_lock(*args)
+        before_dequeue_lock unless lock_running?
         begin
           yield
         ensure
           # Always clear the lock when we're done, even if there is an
           # error.
-          Resque.redis.del(lock(*args))
+          before_dequeue_lock if lock_running?
         end
       end
     end

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -85,6 +85,10 @@ module Resque
           before_dequeue_lock if lock_running?
         end
       end
+
+      def self.clear_all_locks
+        Resque.redis.keys('lock:*').collect { |x| Resque.redis.del(x) }.count
+      end
     end
   end
 end

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -49,11 +49,11 @@ module Resque
       end
 
       def before_enqueue_lock(*args)
-        Resque.redis.hsetnx('resque-lock', lock(*args), true)
+        Resque.redis.setnx(lock(*args), true)
       end
 
       def before_dequeue_lock(*args)
-        Resque.redis.hdel('resque-lock', lock(*args))
+        Resque.redis.del(lock(*args))
       end
 
       def around_perform_lock(*args)
@@ -62,7 +62,7 @@ module Resque
         ensure
           # Always clear the lock when we're done, even if there is an
           # error.
-          Resque.redis.hdel('resque-lock', lock(*args))
+          Resque.redis.del(lock(*args))
         end
       end
     end

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -40,6 +40,21 @@ module Resque
     # UpdateNetworkGraph is running at a time, regardless of the
     # repo_id. Normally a job is locked using a combination of its
     # class name and arguments.
+    # 
+    # It is also possible to define locks which will get released
+    # BEFORE performing a job by overriding the lock_running? class
+    # method in your subclass. This is useful in cases where you need
+    # to get a job queued even if another job on same queue is already
+    # running, e.g.
+    # 
+    # class UpdateNetworkGraph
+    #   extend Resque::Plugins::Lock
+    #
+    #   # Do not lock a running job
+    #   def self.lock_running?
+    #     false
+    #   end
+    # end
     module Lock
       # Override in your job to control the lock key. It is
       # passed the same arguments as `perform`, that is, your job's

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -90,8 +90,11 @@ module Resque
         end
       end
 
+      def self.all_locks
+        Resque.redis.keys('lock:*')
+      end
       def self.clear_all_locks
-        Resque.redis.keys('lock:*').collect { |x| Resque.redis.del(x) }.count
+        all_locks.collect { |x| Resque.redis.del(x) }.count
       end
     end
   end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -16,8 +16,8 @@ class LockTest < Test::Unit::TestCase
 
   def setup
     Resque.redis.del('queue:lock_test')
-    Resque.redis.del(Job.lock)
-    Resque.redis.del(Job.lock(1))
+    Resque.redis.del("lock:#{Job.lock}")
+    Resque.redis.del("lock:#{Job.lock(1)}")
   end
 
   def test_lint
@@ -47,15 +47,15 @@ class LockTest < Test::Unit::TestCase
 
   def test_unlock
     Resque.enqueue(Job)
-    assert_equal "true", Resque.redis.get(Job.lock)
+    assert_equal "true", Resque.redis.get("lock:#{Job.lock}")
     Resque.dequeue(Job)
-    assert_nil Resque.redis.get(Job.lock)
+    assert_nil Resque.redis.get("lock:#{Job.lock}")
   end
   def test_unlock_with_args
     Resque.enqueue(Job, 1)
-    assert_equal "true", Resque.redis.get(Job.lock(1))
+    assert_equal "true", Resque.redis.get("lock:#{Job.lock(1)}")
     Resque.dequeue(Job, 1)
-    assert_nil Resque.redis.get(Job.lock(1))
+    assert_nil Resque.redis.get("lock:#{Job.lock(1)}")
   end
 
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -2,8 +2,6 @@ require 'test/unit'
 require 'resque'
 require 'resque/plugins/lock'
 
-$counter = 0
-
 class LockTest < Test::Unit::TestCase
   class Job
     extend Resque::Plugins::Lock
@@ -16,7 +14,7 @@ class LockTest < Test::Unit::TestCase
 
   def setup
     Resque.redis.del('queue:lock_test')
-    Resque.redis.del(Job.lock)
+    Resque.redis.hdel('resque-lock', Job.lock)
   end
 
   def test_lint
@@ -30,11 +28,19 @@ class LockTest < Test::Unit::TestCase
     assert_equal 1, major.to_i
     assert minor.to_i >= 17
     assert Resque::Plugin.respond_to?(:before_enqueue_hooks)
+    assert Resque::Plugin.respond_to?(:before_dequeue_hooks)
   end
 
   def test_lock
     3.times { Resque.enqueue(Job) }
 
     assert_equal 1, Resque.redis.llen('queue:lock_test')
+    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock)
+  end
+
+  def test_unlock
+    Resque.enqueue(Job)
+    Resque.dequeue(Job)
+    assert_equal nil, Resque.redis.hget('resque-lock', Job.lock)
   end
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -41,6 +41,6 @@ class LockTest < Test::Unit::TestCase
   def test_unlock
     Resque.enqueue(Job)
     Resque.dequeue(Job)
-    assert_equal nil, Resque.redis.hget('resque-lock', Job.lock)
+    assert_nil Resque.redis.hget('resque-lock', Job.lock)
   end
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -46,6 +46,7 @@ class LockTest < Test::Unit::TestCase
 
   def test_unlock
     Resque.enqueue(Job)
+    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock)
     Resque.dequeue(Job)
     assert_nil Resque.redis.hget('resque-lock', Job.lock)
   end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -2,6 +2,8 @@ require 'test/unit'
 require 'resque'
 require 'resque/plugins/lock'
 
+$counter = 0
+
 class LockTest < Test::Unit::TestCase
   class Job
     extend Resque::Plugins::Lock
@@ -14,7 +16,8 @@ class LockTest < Test::Unit::TestCase
 
   def setup
     Resque.redis.del('queue:lock_test')
-    Resque.redis.hdel('resque-lock', Job.lock)
+    Resque.redis.del(Job.lock)
+    Resque.redis.del(Job.lock(1))
   end
 
   def test_lint
@@ -28,33 +31,31 @@ class LockTest < Test::Unit::TestCase
     assert_equal 1, major.to_i
     assert minor.to_i >= 17
     assert Resque::Plugin.respond_to?(:before_enqueue_hooks)
-    assert Resque::Plugin.respond_to?(:before_dequeue_hooks)
   end
 
   def test_lock
     3.times { Resque.enqueue(Job) }
 
     assert_equal 1, Resque.redis.llen('queue:lock_test')
-    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock)
   end
+
   def test_lock_with_args
     3.times { Resque.enqueue(Job, 1) }
 
     assert_equal 1, Resque.redis.llen('queue:lock_test')
-    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock(1))
   end
 
   def test_unlock
     Resque.enqueue(Job)
-    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock)
+    assert_equal "true", Resque.redis.get(Job.lock)
     Resque.dequeue(Job)
-    assert_nil Resque.redis.hget('resque-lock', Job.lock)
+    assert_nil Resque.redis.get(Job.lock)
   end
   def test_unlock_with_args
     Resque.enqueue(Job, 1)
-    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock(1))
+    assert_equal "true", Resque.redis.get(Job.lock(1))
     Resque.dequeue(Job, 1)
-    assert_nil Resque.redis.hget('resque-lock', Job.lock(1))
+    assert_nil Resque.redis.get(Job.lock(1))
   end
-  
+
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -37,10 +37,23 @@ class LockTest < Test::Unit::TestCase
     assert_equal 1, Resque.redis.llen('queue:lock_test')
     assert_equal "true", Resque.redis.hget('resque-lock', Job.lock)
   end
+  def test_lock_with_args
+    3.times { Resque.enqueue(Job, 1) }
+
+    assert_equal 1, Resque.redis.llen('queue:lock_test')
+    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock(1))
+  end
 
   def test_unlock
     Resque.enqueue(Job)
     Resque.dequeue(Job)
     assert_nil Resque.redis.hget('resque-lock', Job.lock)
   end
+  def test_unlock_with_args
+    Resque.enqueue(Job, 1)
+    assert_equal "true", Resque.redis.hget('resque-lock', Job.lock(1))
+    Resque.dequeue(Job, 1)
+    assert_nil Resque.redis.hget('resque-lock', Job.lock(1))
+  end
+  
 end


### PR DESCRIPTION
Unlocks a queue when dequeue is called, using the before dequeue hook (see: https://github.com/humancopy/resque/commit/5042244f486b8ee976926f4b4007de182718f0ef).

It also stores the lock in a hash so it's easier to remove all locks if needed.

There are still deadlocks happening when using Resque.remove_queue to remove the whole queue. Still thinking on this one... :)
