### PR TITLE
Normalize args when deriving the redis lock key.

### DIFF
--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -49,7 +49,8 @@ module Resque
       end
 
       def before_enqueue_lock(*args)
-        Resque.redis.setnx(lock(*args), true)
+        normalized_args = Resque.decode(Resque.encode(args))
+        Resque.redis.setnx(lock(*normalized_args), true)
       end
 
       def around_perform_lock(*args)


### PR DESCRIPTION
Otherwise, the before_enqueue_lock will create a different redis key than around_perform_lock deletes.

This can be tested by using a symbol in the arguments, which gets encoded as a string.  A regression test was added to unsure this issue is handled.
