### PR TITLE
Lock Argument Fix

### DIFF
--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -53,7 +53,7 @@ module Resque
       # passed the same arguments as `perform`, that is, your job's
       # payload.
       def lock(*args)
-        "lock:#{name}-#{args.to_s}"
+        "lock:#{name}-#{Resque.encode(args)}"
       end
 
       # See the documentation for SETNX http://redis.io/commands/setnx for an

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -42,6 +42,14 @@ class LockTest < Test::Unit::TestCase
     assert_equal 1, Resque.redis.llen('queue:lock_test')
   end
 
+  def test_lock_arguments
+    client_arguments = :test
+    client_lock = Job.lock(client_arguments)
+    job_arguments = Resque.decode(Resque.encode(client_arguments))
+    job_lock = Job.lock(job_arguments)
+    assert_equal client_lock, job_lock
+  end
+
   def test_deadlock
     now = Time.now.to_i
 


### PR DESCRIPTION
When some arguments types are used (eg Symbols), the lock mechanism fails to calculate the same lock key in the client (before queue) and in the job (around perform).

This is because of the difference between the encoding/decoding for passing arguments to jobs and the `to_s` inspect method used to construct the lock key.

I switched the lock key construction to use `Resque.encode` instead of `to_s`.

Test included.
