### PR TITLE
Expire stale queued jobs on lock timeout expiration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gem "resque"
 group :development do
   gem "turn"
   gem "rake"
+  gem 'json'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'rake/testtask'
-require 'rake/rdoctask'
 
 def command?(command)
   system("type #{command} > /dev/null")

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -70,8 +70,9 @@ module Resque
         # (we cannot acquire the lock during the timeout period)
         return false if now <= Resque.redis.get(key).to_i
 
-        # otherwise set the timeout and ensure that no other worker has
-        # acquired the lock
+        # otherwise dequeue the job holding the current lock and reset the
+        # timeout to ensure that no other worker has acquired the lock
+        Resque.dequeue(self, *args)
         now > Resque.redis.getset(key, timeout).to_i
       end
 

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -87,7 +87,7 @@ module Resque
       end
 
       # Some errors may not be capture by above `ensure'. Handle it here.
-      def on_failure_lock
+      def on_failure_lock(exception, *args)
         Resque.redis.del(lock(*args))
       end
     end

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -85,6 +85,11 @@ module Resque
           Resque.redis.del(lock(*args))
         end
       end
+
+      # Some errors may not be capture by above `ensure'. Handle it here.
+      def on_failure_lock
+        Resque.redis.del(lock(*args))
+      end
     end
   end
 end

--- a/resque-lock.gemspec
+++ b/resque-lock.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "resque-lock"
-  s.version           = "1.1.0"
+  s.version           = "1.1.1"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "A Resque plugin for ensuring only one instance of your job is queued at a time."
   s.homepage          = "http://github.com/defunkt/resque-lock"

--- a/resque-lock.gemspec
+++ b/resque-lock.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "resque-lock"
-  s.version           = "1.1.2"
+  s.version           = "1.1.3"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "A Resque plugin for ensuring only one instance of your job is queued at a time."
   s.homepage          = "http://github.com/defunkt/resque-lock"

--- a/resque-lock.gemspec
+++ b/resque-lock.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "resque-lock"
-  s.version           = "1.1.1"
+  s.version           = "1.1.2"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "A Resque plugin for ensuring only one instance of your job is queued at a time."
   s.homepage          = "http://github.com/defunkt/resque-lock"

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -55,6 +55,6 @@ class LockTest < Test::Unit::TestCase
 
     sleep 3
     Resque.enqueue(Job)
-    assert_equal 2, Resque.redis.llen('queue:lock_test')
+    assert_equal 1, Resque.redis.llen('queue:lock_test')
   end
 end


### PR DESCRIPTION
If no workers pull the lock-holding job from the queue, additional jobs are able to be queued after the lock timeout expires.

If we're about to expire the lock, ensure that the stale job is removed from the queue
