### PR TITLE
Allow jobs to be queuable once the existing job starts performing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,22 @@ UpdateNetworkGraph is queued at a time, regardless of the
 repo_id. Normally a job is locked using a combination of its
 class name and arguments.
 
+If you don't want to have to wait until a job has completed
+before being able to enqueue another job with the same
+arguments, you can set the `unlock_while_performing` flag:
+
+    class UpdateNetworkGraph
+      extend Resque::Plugins::Lock
+      @unlock_while_performing = true
+
+      # etc ...
+    end
+
+With this option set, another job of the same type with the
+same arguments can be queued even while the original one is
+being performed. Otherwise, the queue will remain locked
+until the job has completed. This option can be useful if you
+know that some data has changed which the currently-performing
+job will not have taken into account.
+
 [rq]: http://github.com/defunkt/resque

--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -75,6 +75,10 @@ module Resque
         now > Resque.redis.getset(key, timeout).to_i
       end
 
+      def before_perform_lock(*args)
+        Resque.redis.del(lock(*args)) if @unlock_while_performing
+      end
+
       def around_perform_lock(*args)
         begin
           yield


### PR DESCRIPTION
This is useful when you know that the currently running job might not be
taking into account the most recent updates to some of the data it is
operating on, which can occur when the jobs take some time to run.

For example:
1. update model
2. queue job to index in ElasticSearch
3. job starts performing
4. another update happens to the model
5. try to queue job to update index

With the default queue locking mechanism, step 5 will only succeed in
enqueuing a new job if the job that started in step 3 has already
completed. However, if that job hasn't finished, but has loaded the
model with only the changes from step 1, then the changes introduced in
step 4 won't get indexed.

With `unlock_while_performing` set to true, there can always be a single
pending job in the queue, even when there's also a job running, and so
we can be confident that any un-indexed changes to the model will get
indexed once the final job finishes running.
