### PR TITLE
handle symbolic args

### DIFF
--- a/lib/resque/plugins/lock.rb
+++ b/lib/resque/plugins/lock.rb
@@ -53,6 +53,7 @@ module Resque
       # passed the same arguments as `perform`, that is, your job's
       # payload.
       def lock(*args)
+        args.map! { |a| a.is_a?(Symbol) ? a.to_s : a }
         "lock:#{name}-#{args.to_s}"
       end
 


### PR DESCRIPTION
Symbolic arguments (method names) cause the key to be rendered differently in #before_enqueue_lock and #around_perform_lock causing the lock to not be released from `ensure`.

From my logging

```
    # INFO -- : clearing lock:ProductSaleStatsUpdate-[nil, "commit_all_updates"]
    # INFO -- : 1534985063 lock:ProductSaleStatsUpdate-[nil, :commit_all_updates]
```